### PR TITLE
Fix minor bugs in encode_{corpus,datasets}.py

### DIFF
--- a/mdr/retrieval/data/encode_datasets.py
+++ b/mdr/retrieval/data/encode_datasets.py
@@ -45,7 +45,7 @@ class EmDataset(Dataset):
         self.max_c_len = max_c_len
 
         if not os.path.exists(save_path):
-            os.makedir(save_path)
+            os.mkdir(save_path)
         save_path = os.path.join(save_path, "id2doc.json") # ID to doc mapping
 
         print(f"Loading data from {data_path}")

--- a/scripts/encode_corpus.py
+++ b/scripts/encode_corpus.py
@@ -66,7 +66,7 @@ def main():
     tokenizer = AutoTokenizer.from_pretrained(args.model_name)
 
     eval_dataset = EmDataset(
-        tokenizer, args.predict_file, args.max_q_len, args.max_c_len, args.is_query_embed)
+        tokenizer, args.predict_file, args.max_q_len, args.max_c_len, args.is_query_embed, args.embed_save_path)
     eval_dataloader = DataLoader(
         eval_dataset, batch_size=args.predict_batch_size, collate_fn=em_collate, pin_memory=True, num_workers=args.num_workers)
 


### PR DESCRIPTION
Two-line fixes for missing arguments and typo in function name for encoding the corpus.