### PR TITLE
fix retriever training script

### DIFF
--- a/mdr/retrieval/criterions.py
+++ b/mdr/retrieval/criterions.py
@@ -140,7 +140,7 @@ def mhop_loss(model, batch, args):
 
         scores_1_hop = torch.cat([scores_1_hop, queue_neg_scores_1], dim=1)
         scores_2_hop = torch.cat([scores_2_hop, queue_neg_scores_2], dim=1)
-        model.module.dequeue_and_enqueue(all_ctx.detach())
+        model.dequeue_and_enqueue(all_ctx.detach())
         # model.module.momentum_update_key_encoder()
 
     target_1_hop = torch.arange(outputs["q"].size(0)).to(outputs["q"].device)

--- a/mdr/retrieval/criterions.py
+++ b/mdr/retrieval/criterions.py
@@ -132,8 +132,8 @@ def mhop_loss(model, batch, args):
     scores_2_hop = torch.cat([scores_2_hop, neg_scores_2], dim=1)
 
     if args.momentum:
-        queue_neg_scores_1 = torch.mm(outputs["q"], model.module.queue.clone().detach().t())
-        queue_neg_scores_2 = torch.mm(outputs["q_sp1"], model.module.queue.clone().detach().t())
+        queue_neg_scores_1 = torch.mm(outputs["q"], model.queue.clone().detach().t())
+        queue_neg_scores_2 = torch.mm(outputs["q_sp1"], model.queue.clone().detach().t())
 
         # queue_neg_scores_1 = queue_neg_scores_1 / args.temperature
         # queue_neg_scores_2 = queue_neg_scores_2 / args.temperature  

--- a/scripts/train_momentum.py
+++ b/scripts/train_momentum.py
@@ -183,9 +183,9 @@ def main():
                         if best_mrr < mrr:
                             logger.info("Saving model with best MRR %.2f -> MRR %.2f on epoch=%d" %
                                         (best_mrr*100, mrr*100, epoch))
-                            torch.save(model.module.encoder_q.state_dict(), os.path.join(
+                            torch.save(model.encoder_q.state_dict(), os.path.join(
                                 args.output_dir, f"checkpoint_q_best.pt"))
-                            torch.save(model.module.encoder_q.state_dict(), os.path.join(
+                            torch.save(model.encoder_q.state_dict(), os.path.join(
                                 args.output_dir, f"checkpoint_k_best.pt"))
                             model = model.to(device)
                             best_mrr = mrr
@@ -199,9 +199,9 @@ def main():
 
             if best_mrr < mrr:
                 logger.info("Saving model with best MRR %.2f -> MRR %.2f on epoch=%d" % (best_mrr*100, mrr*100, epoch))
-                torch.save(model.module.encoder_q.state_dict(), os.path.join(
+                torch.save(model.encoder_q.state_dict(), os.path.join(
                     args.output_dir, f"checkpoint_q_best.pt"))
-                torch.save(model.module.encoder_q.state_dict(), os.path.join(
+                torch.save(model.encoder_q.state_dict(), os.path.join(
                     args.output_dir, f"checkpoint_k_best.pt"))
                 best_mrr = mrr
 

--- a/scripts/train_momentum.py
+++ b/scripts/train_momentum.py
@@ -183,10 +183,17 @@ def main():
                         if best_mrr < mrr:
                             logger.info("Saving model with best MRR %.2f -> MRR %.2f on epoch=%d" %
                                         (best_mrr*100, mrr*100, epoch))
-                            torch.save(model.encoder_q.state_dict(), os.path.join(
-                                args.output_dir, f"checkpoint_q_best.pt"))
-                            torch.save(model.encoder_q.state_dict(), os.path.join(
-                                args.output_dir, f"checkpoint_k_best.pt"))
+                            if n_gpu > 1:
+                                # Using DataParallel -> need to call model.module
+                                torch.save(model.module.encoder_q.state_dict(), os.path.join(
+                                    args.output_dir, f"checkpoint_q_best.pt"))
+                                torch.save(model.module.encoder_q.state_dict(), os.path.join(
+                                    args.output_dir, f"checkpoint_k_best.pt"))
+                            else:
+                                torch.save(model.encoder_q.state_dict(), os.path.join(
+                                    args.output_dir, f"checkpoint_q_best.pt"))
+                                torch.save(model.encoder_q.state_dict(), os.path.join(
+                                    args.output_dir, f"checkpoint_k_best.pt"))
                             model = model.to(device)
                             best_mrr = mrr
 
@@ -199,10 +206,17 @@ def main():
 
             if best_mrr < mrr:
                 logger.info("Saving model with best MRR %.2f -> MRR %.2f on epoch=%d" % (best_mrr*100, mrr*100, epoch))
-                torch.save(model.encoder_q.state_dict(), os.path.join(
-                    args.output_dir, f"checkpoint_q_best.pt"))
-                torch.save(model.encoder_q.state_dict(), os.path.join(
-                    args.output_dir, f"checkpoint_k_best.pt"))
+                if n_gpu > 1:
+                    # Using DataParallel -> need to call model.module
+                    torch.save(model.module.encoder_q.state_dict(), os.path.join(
+                        args.output_dir, f"checkpoint_q_best.pt"))
+                    torch.save(model.module.encoder_q.state_dict(), os.path.join(
+                        args.output_dir, f"checkpoint_k_best.pt"))
+                else:
+                    torch.save(model.encoder_q.state_dict(), os.path.join(
+                        args.output_dir, f"checkpoint_q_best.pt"))
+                    torch.save(model.encoder_q.state_dict(), os.path.join(
+                        args.output_dir, f"checkpoint_k_best.pt"))
                 best_mrr = mrr
 
         logger.info("Training finished!")


### PR DESCRIPTION
In `train_momentum.py` `model` is an instance of `RobertaMomentumRetriever`. In a few places the script calls `model.module.encoder_q.state_dict()` , as well as `model.module.queue.clone().detach().t()` from `mdr.retrieval.criterions.mhop_loss` . However, `RobertaMomentumRetriever`  doesn't actually have a `module` attribute, so the script throws an error. I believe these should be replaced with `model.encoder_q.state_dict()`  and `model.queue.clone().detach().t()`